### PR TITLE
Fix test dependency

### DIFF
--- a/tdd/server.test.js
+++ b/tdd/server.test.js
@@ -2,6 +2,7 @@
 const request = require('supertest');
 const express = require('express');
 const MongoClient = require('mongodb').MongoClient;
+const { MongoMemoryServer } = require('mongodb-memory-server');
 let app, mongoServer, db, collection;
 
 beforeAll(async () => {


### PR DESCRIPTION
## Summary
- add missing import for `MongoMemoryServer` in test suite

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_6843071fc354832b9044d98ac6f50166